### PR TITLE
Fix OAuth paths and update landing page

### DIFF
--- a/integrations/common/src/main/java/com/enterprise/agents/common/controller/BaseOAuthController.java
+++ b/integrations/common/src/main/java/com/enterprise/agents/common/controller/BaseOAuthController.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("/api/oauth")
+@RequestMapping("/oauth")
 public abstract class BaseOAuthController {
     protected final IntegrationService integrationService;
     protected final IntegrationLoggingService loggingService;

--- a/integrations/github/src/main/java/com/enterprise/agents/github/controller/GitHubOAuthController.java
+++ b/integrations/github/src/main/java/com/enterprise/agents/github/controller/GitHubOAuthController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/github")
 @RequiredArgsConstructor
 public class GitHubOAuthController {
     private final @Qualifier("gitHubConfig") OAuthConfig oauthConfig;

--- a/integrations/jira/src/main/java/com/enterprise/agents/jira/controller/JiraOAuthController.java
+++ b/integrations/jira/src/main/java/com/enterprise/agents/jira/controller/JiraOAuthController.java
@@ -4,11 +4,9 @@ import com.enterprise.agents.common.controller.BaseOAuthController;
 import com.enterprise.agents.common.service.IntegrationLoggingService;
 import com.enterprise.agents.common.service.IntegrationService;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/jira")
 public class JiraOAuthController extends BaseOAuthController {
     public JiraOAuthController(@Qualifier("jiraIntegrationService") IntegrationService integrationService, IntegrationLoggingService loggingService) {
         super(integrationService, loggingService);

--- a/ui-app/src/components/LandingPage.jsx
+++ b/ui-app/src/components/LandingPage.jsx
@@ -59,13 +59,13 @@ const LandingPage = () => {
               Onboarding App
             </Typography>
           </Box>
-          <Typography variant="h5" sx={{ 
+          <Typography variant="h5" sx={{
             mb: 4,
             color: 'rgba(255, 255, 255, 0.9)',
             maxWidth: '800px',
             textAlign: 'center'
           }}>
-            Streamline your team onboarding process with our powerful automation platform
+            Elevate team onboarding with seamless automation and integrations
           </Typography>
           <Button
             variant="contained"

--- a/ui-app/src/services/api.js
+++ b/ui-app/src/services/api.js
@@ -2,10 +2,10 @@ export const API_BASE_URL = 'http://localhost:8085/api';
 
 // Integration Services
 const INTEGRATION_SERVICES = {
-  slack: { port: 8081, baseUrl: 'http://localhost:8081' },
-  jira: { port: 8082, baseUrl: 'http://localhost:8082' },
-  github: { port: 8083, baseUrl: 'http://localhost:8083' },
-  google: { port: 8084, baseUrl: 'http://localhost:8084' }
+  slack: { port: 8083, baseUrl: 'http://localhost:8083' },
+  jira: { port: 8084, baseUrl: 'http://localhost:8084' },
+  github: { port: 8081, baseUrl: 'http://localhost:8081' },
+  google: { port: 8082, baseUrl: 'http://localhost:8082' }
 };
 
 // Teams API


### PR DESCRIPTION
## Summary
- correct service port mapping in UI API helper
- simplify OAuth controller mappings so paths are consistent
- refresh landing page tagline

## Testing
- `npm test --silent` *(fails: react-scripts not found)*
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684521f04614832193d7f25de349292e