### PR TITLE
Fix OAuthConfig secret getter

### DIFF
--- a/integrations/common/src/main/java/com/enterprise/agents/common/config/OAuthConfig.java
+++ b/integrations/common/src/main/java/com/enterprise/agents/common/config/OAuthConfig.java
@@ -35,7 +35,7 @@ public class OAuthConfig {
     }
 
     public String getClientSecret() {
-        return jiraScope;
+        return jiraClientSecret;
     }
 
     public String getRedirectUri() {


### PR DESCRIPTION
## Summary
- fix incorrect return value in `OAuthConfig.getClientSecret`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684510689c7883218b83d02604f572b1