### PR TITLE
Align nginx example ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The `nginx.conf` file in the project root configures Nginx as a reverse proxy fo
 ```nginx
 # Health check endpoints
 location /health/api {
-    proxy_pass http://localhost:8081/actuator/health;
+    proxy_pass http://localhost:8080/actuator/health;
 }
 location /health/slack {
     proxy_pass http://localhost:8083/actuator/health;
@@ -202,17 +202,20 @@ location /health/google {
 }
 
 # API endpoints
+location /api/sso/ {
+    proxy_pass http://localhost:8080/api/sso/;
+}
 location /api/jira/ {
     proxy_pass http://localhost:8084/api/jira/;
 }
 location /api/slack/ {
-    proxy_pass http://localhost:8081/api/slack/;
+    proxy_pass http://localhost:8083/api/slack/;
 }
 location /api/github/ {
-    proxy_pass http://localhost:8082/api/github/;
+    proxy_pass http://localhost:8081/api/github/;
 }
 location /api/google/ {
-    proxy_pass http://localhost:8083/api/google/;
+    proxy_pass http://localhost:8082/api/google/;
 }
 ```
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -6,24 +6,24 @@ http {
 
         # Health check endpoints
         location /health/api {
-            proxy_pass http://localhost:8081/actuator/health;
+            proxy_pass http://localhost:8080/actuator/health;
         }
         location /health/slack {
             proxy_pass http://localhost:8083/actuator/health;
         }
         location /health/github {
-            proxy_pass http://localhost:8083/actuator/health;
+            proxy_pass http://localhost:8081/actuator/health;
         }
         location /health/jira {
-            proxy_pass http://localhost:8082/actuator/health;
+            proxy_pass http://localhost:8084/actuator/health;
         }
         location /health/google {
-            proxy_pass http://localhost:8084/actuator/health;
+            proxy_pass http://localhost:8082/actuator/health;
         }
 
         # API endpoints
         location /api/sso/ {
-            proxy_pass http://localhost:8081/api/sso/;
+            proxy_pass http://localhost:8080/api/sso/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -31,7 +31,7 @@ http {
             proxy_pass_header Set-Cookie;
         }
         location /api/jira/ {
-            proxy_pass http://localhost:8082/api/jira/;
+            proxy_pass http://localhost:8084/api/jira/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -47,7 +47,7 @@ http {
             proxy_pass_header Set-Cookie;
         }
         location /api/github/ {
-            proxy_pass http://localhost:8083/api/github/;
+            proxy_pass http://localhost:8081/api/github/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -55,7 +55,7 @@ http {
             proxy_pass_header Set-Cookie;
         }
         location /api/google/ {
-            proxy_pass http://localhost:8084/api/google/;
+            proxy_pass http://localhost:8082/api/google/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- fix ports in README's nginx snippet
- update nginx.conf to use service ports
- include `/api/sso` example in README

## Testing
- `mvn -q test` *(fails: command not found)*
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_68451065f5848321b9bc3d6c8372ff8c