### PR TITLE
Fix nginx configuration snippet ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The `nginx.conf` file in the project root configures Nginx as a reverse proxy fo
 ```nginx
 # Health check endpoints
 location /health/api {
-    proxy_pass http://localhost:8081/actuator/health;
+    proxy_pass http://localhost:8085/actuator/health;
 }
 location /health/slack {
     proxy_pass http://localhost:8083/actuator/health;
@@ -206,13 +206,13 @@ location /api/jira/ {
     proxy_pass http://localhost:8084/api/jira/;
 }
 location /api/slack/ {
-    proxy_pass http://localhost:8081/api/slack/;
+    proxy_pass http://localhost:8083/api/slack/;
 }
 location /api/github/ {
-    proxy_pass http://localhost:8082/api/github/;
+    proxy_pass http://localhost:8081/api/github/;
 }
 location /api/google/ {
-    proxy_pass http://localhost:8083/api/google/;
+    proxy_pass http://localhost:8082/api/google/;
 }
 ```
 


### PR DESCRIPTION
## Summary
- fix port numbers in README nginx snippet to match config and UI

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684573ccc0dc8321a671fa40a84c5208