### PR TITLE
Add dependency installer and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ OAuth tokens. It is designed to facilitate secure service integrations and token
     - `google/`: Google Calendar integration service
     - `jira/`: Jira integration service
     - `slack/`: Slack integration service
-- `slack-onboarding-ui/`: Frontend UI application (React)
+- `ui-app/`: Frontend UI application (React)
 
 ## Prerequisites
 
-- Java 23+
+- Java 17+
 - Maven 3.6+
 - Node.js 18+ (for UI)
 - Redis (for token storage)
@@ -30,7 +30,13 @@ OAuth tokens. It is designed to facilitate secure service integrations and token
    cd <repo-root>
    ```
 
-2. **Configure environment variables**
+2. **Install prerequisites**
+   Run the helper script to install Java, Maven, Node.js, Redis and Nginx on Debian/Ubuntu systems:
+   ```sh
+   ./install-dependencies.sh
+   ```
+
+3. **Configure environment variables**
    For each integration service, configure the respective credentials in their `application.properties` files:
 
     - GitHub (`integrations/github/src/main/resources/application.properties`):
@@ -102,7 +108,7 @@ Each integration service runs on its own port:
 
 1. Install dependencies and run the UI:
    ```sh
-   cd slack-onboarding-ui
+   cd ui-app
    npm install
    npm start
    ```
@@ -214,6 +220,15 @@ location /api/github/ {
 location /api/google/ {
     proxy_pass http://localhost:8083/api/google/;
 }
+```
+
+## Running Tests
+
+Run backend and frontend tests to verify the installation:
+
+```sh
+mvn test
+npm test --prefix ui-app
 ```
 
 ## Development Notes

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -7,6 +7,10 @@
 
 set -e
 
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run this script as root or with sudo." >&2
+  exit 1
+fi
 if ! command -v apt-get >/dev/null; then
   echo "apt-get not found. Please install Java, Maven, Node.js, Redis and Nginx manually." >&2
   exit 1

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Installs required packages for running the Onboarding App.
+# This script targets Debian/Ubuntu systems using apt-get. For other
+# platforms, install Java 17+, Maven 3.6+, Node.js 18+, Redis and Nginx
+# using your system's package manager.
+
+set -e
+
+if ! command -v apt-get >/dev/null; then
+  echo "apt-get not found. Please install Java, Maven, Node.js, Redis and Nginx manually." >&2
+  exit 1
+fi
+
+sudo apt-get update
+sudo apt-get install -y openjdk-17-jdk maven redis-server nginx curl
+
+# Install Node.js 18 from NodeSource
+curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+echo "All dependencies installed."


### PR DESCRIPTION
## Summary
- add `install-dependencies.sh` to automate installing Java, Maven, Node, Redis and Nginx
- document new script in README
- fix UI path and update Java version requirement
- add instructions for running tests

## Testing
- `mvn -q test` *(fails: `mvn` not found)*
- `npm test --prefix ui-app` *(fails: `react-scripts` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845740988c48321942605b0556d0245