### PR TITLE
Validate URL in HttpHelper and update isConnected method in JiraService

### DIFF
--- a/api-layer/src/main/java/com/service/api/helpers/HttpHelper.java
+++ b/api-layer/src/main/java/com/service/api/helpers/HttpHelper.java
@@ -40,7 +40,7 @@ public class HttpHelper {
             // Validate that the URL is absolute
             try {
                 new java.net.URL(url);
-            } catch (Exception e) {
+            } catch (MalformedURLException e) {
                 throw new IllegalArgumentException("Invalid URL: " + url, e);
             }
 

--- a/api-layer/src/main/java/com/service/api/helpers/HttpHelper.java
+++ b/api-layer/src/main/java/com/service/api/helpers/HttpHelper.java
@@ -37,6 +37,13 @@ public class HttpHelper {
         HttpURLConnection httpURLConnection = null;
         int connectionTimeout = REST_CLIENT_TIMEOUT_MS;
         try {
+            // Validate that the URL is absolute
+            try {
+                new java.net.URL(url);
+            } catch (Exception e) {
+                throw new IllegalArgumentException("Invalid URL: " + url, e);
+            }
+
             httpURLConnection = createHttpUrlConnection(url);
             httpURLConnection.setDoOutput(doOutput);
             httpURLConnection.setRequestMethod(requestMethod);

--- a/integrations/jira/src/main/java/com/enterprise/agents/jira/service/JiraService.java
+++ b/integrations/jira/src/main/java/com/enterprise/agents/jira/service/JiraService.java
@@ -79,7 +79,7 @@ public class JiraService {
     }
 
     public boolean isConnected(String enterpriseId) {
-        return tokenRepository.findByEnterpriseId(enterpriseId) != null;
+        return tokenRepository.findByEnterpriseId(enterpriseId).isPresent();
     }
 
     public void disconnect(String enterpriseId) {


### PR DESCRIPTION
Fix JiraService.isConnected logic and add URL validation to HttpHelper

- JiraService.isConnected now correctly checks Optional presence, fixing test failures.
- HttpHelper.buildHttpURLConnection now validates that URLs are absolute, preventing runtime errors on invalid input.
